### PR TITLE
edit ribcage scale without having to restart

### DIFF
--- a/FovPatches.cs
+++ b/FovPatches.cs
@@ -407,16 +407,45 @@ namespace FOVFix
     //changes "HUD FOV", or how the player model is rendered
     public class CalculateScaleValueByFovPatch : ModulePatch
     {
+        private static Player player;
+        
         protected override MethodBase GetTargetMethod()
         {
             return typeof(Player).GetMethod("CalculateScaleValueByFov");
         }
 
-        [PatchPrefix]
-        public static bool Prefix(ref float ____ribcageScaleCompensated)
+        public static void UpdateRibcageScale(float newScale)
         {
-            ____ribcageScaleCompensated = Plugin.FovScale.Value;
-            return false;
+            if (player != null)
+            {
+                player.RibcageScaleCurrentTarget = newScale;
+            }
+        }
+
+        public static void RestoreScale()
+        {
+            if (player != null)
+            {
+                player.CalculateScaleValueByFov(CameraClass.Instance.Fov);
+                player.SetCompensationScale(true);
+            }
+        }
+
+        [PatchPrefix]
+        public static bool Prefix(Player __instance, ref float ____ribcageScaleCompensated)
+        {
+            float scale = Plugin.FovScale.Value;
+            player = __instance;
+
+            if (Plugin.EnableFovScaleFix.Value)
+            {
+                ____ribcageScaleCompensated = scale;
+                UpdateRibcageScale(scale);
+            
+                return false;
+            }
+
+            return true;
         }
     }
 

--- a/FovPatches.cs
+++ b/FovPatches.cs
@@ -407,8 +407,6 @@ namespace FOVFix
     //changes "HUD FOV", or how the player model is rendered
     public class CalculateScaleValueByFovPatch : ModulePatch
     {
-        private static Player player;
-        
         protected override MethodBase GetTargetMethod()
         {
             return typeof(Player).GetMethod("CalculateScaleValueByFov");
@@ -416,6 +414,8 @@ namespace FOVFix
 
         public static void UpdateRibcageScale(float newScale)
         {
+            Player player = Singleton<GameWorld>.Instance.MainPlayer;
+            
             if (player != null)
             {
                 player.RibcageScaleCurrentTarget = newScale;
@@ -424,6 +424,8 @@ namespace FOVFix
 
         public static void RestoreScale()
         {
+            Player player = Singleton<GameWorld>.Instance.MainPlayer;
+            
             if (player != null)
             {
                 player.CalculateScaleValueByFov(CameraClass.Instance.Fov);
@@ -435,7 +437,6 @@ namespace FOVFix
         public static bool Prefix(Player __instance, ref float ____ribcageScaleCompensated)
         {
             float scale = Plugin.FovScale.Value;
-            player = __instance;
 
             if (Plugin.EnableFovScaleFix.Value)
             {

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -155,8 +155,8 @@ namespace FOVFix
             HighSensMulti = Config.Bind<float>(sens, "High Sens Multi", 0.01f, new ConfigDescription("", new AcceptableValueRange<float>(0.001f, 2f), new ConfigurationManagerAttributes { Order = 1 }));
 
             HudFOV = Config.Bind<float>(misc, "Hud FOV", 0.025f, new ConfigDescription("How Far Away The Player Camera Is From The Player's Arms And Weapon, Making Them Appear Closer/Larger Or Further Away/Smaller", new AcceptableValueRange<float>(-0.1f, 0.1f), new ConfigurationManagerAttributes { Order = 20 }));
-            EnableFovScaleFix = Config.Bind<bool>(misc, "Enable FOV Scale Fix", false, new ConfigDescription("Requires Game Restart. Lower Value = More Distortion.", null, new ConfigurationManagerAttributes { Order = 10, IsAdvanced = true }));
-            FovScale = Config.Bind<float>(misc, "FOV Scale", 1f, new ConfigDescription("Requires Game Restart. A Value Of One Reduces The Distortion Caused By Higher FOV Settings, Significantly Reducing Issues With Laser Misallignment And Optics Recoil. Does Make Weapon Postion And Scale Look Different.", new AcceptableValueRange<float>(0f, 2f), new ConfigurationManagerAttributes { Order = 4, IsAdvanced = true }));
+            EnableFovScaleFix = Config.Bind<bool>(misc, "Enable FOV Scale Fix", false, new ConfigDescription("Lower Value = More Viewmodel Distortion.", null, new ConfigurationManagerAttributes { Order = 10, IsAdvanced = true }));
+            FovScale = Config.Bind<float>(misc, "FOV Scale", 1f, new ConfigDescription("Viewmodel FOV. A Value Of One Reduces The Distortion Caused By Higher FOV Settings, Significantly Reducing Issues With Laser Misallignment And Optics Recoil. Does Make Weapon Postion And Scale Look Different.", new AcceptableValueRange<float>(0f, 2f), new ConfigurationManagerAttributes { Order = 4, IsAdvanced = true }));
             MaxBaseFOV = Config.Bind<int>(misc, "Max Base FOV", 110, new ConfigDescription("Max Selectable Main Camera FOV In Game Settings.", new AcceptableValueRange<int>(1, 200), new ConfigurationManagerAttributes { Order = 2 }));
             MinBaseFOV = Config.Bind<int>(misc, "Min Base FOV", 30, new ConfigDescription("Min Selectable Main Camera FOVIn Game Settings.", new AcceptableValueRange<int>(1, 200), new ConfigurationManagerAttributes { Order = 1 }));
 
@@ -171,6 +171,26 @@ namespace FOVFix
             AimSpeedZ = Config.Bind<float>(cameraSpeed, "Camera Aim Speed Z-Axis", 3f, new ConfigDescription("The Speed Of The Player Camera When Aiming For The Z-Axis Specifically", new AcceptableValueRange<float>(0f, 10f), new ConfigurationManagerAttributes { Order = 11 }));
             UnAimSpeedZ = Config.Bind<float>(cameraSpeed, "Camera Un-Aim Speed Z-Axis", 4.5f, new ConfigDescription("The Speed Of The Player Camera When Un-Aiming For The Z-Axis Specifically", new AcceptableValueRange<float>(0f, 10f), new ConfigurationManagerAttributes { Order = 2 }));
 
+            EnableFovScaleFix.SettingChanged += (obj, args) =>
+            {
+                if (EnableFovScaleFix.Value)
+                {
+                    CalculateScaleValueByFovPatch.UpdateRibcageScale(FovScale.Value);
+                }
+                else
+                {
+                    CalculateScaleValueByFovPatch.RestoreScale();
+                }
+            };
+            
+            FovScale.SettingChanged += (obj, args) =>
+            {
+                if (EnableFovScaleFix.Value)
+                {
+                    CalculateScaleValueByFovPatch.UpdateRibcageScale(FovScale.Value);
+                }
+            };
+            
             Utils.Logger = Logger;  
             FovController = new FovController();
 
@@ -183,7 +203,7 @@ namespace FOVFix
             new ScopeSensitivityPatch().Enable();
             new CloneItemPatch().Enable();
             new SetPlayerAimingPatch().Enable();
-            if (Plugin.EnableFovScaleFix.Value) new CalculateScaleValueByFovPatch().Enable();
+            new CalculateScaleValueByFovPatch().Enable();
 
         }
 


### PR DESCRIPTION
changes CalculateScaleByFov patch and configs to enable changing viewmodel fov scaling without having to restart tarkov. 